### PR TITLE
Feature/approve reject

### DIFF
--- a/app/controllers/application_pets_controller.rb
+++ b/app/controllers/application_pets_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationPetsController < ApplicationController
   def update
-    application_pet = ApplicationPet.where(application_id: params[:aid])
-# require 'pry'; binding.pry
+    application_pet = ApplicationPet.current_app(params[:aid], params[:pid])
+    application_pet.update(status: params[:status_update].to_i)
     redirect_to "/admin/applications/#{params[:aid]}"
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -8,8 +8,8 @@ class Application < ApplicationRecord
   validates :status, presence: true
   # validates :qualifications, presence: false
 
-  has_many :application_pets
-  has_many :pets, through: :application_pets
+  has_many :application_pets, dependent: :destroy
+  has_many :pets, through: :application_pets, dependent: :destroy
 
   def status_in_progress
     self.status == "In Progress"

--- a/app/models/application_pet.rb
+++ b/app/models/application_pet.rb
@@ -2,4 +2,12 @@ class ApplicationPet < ApplicationRecord
   belongs_to :application
   belongs_to :pet
   enum :status, {Pending: 0, Accepted: 1, Rejected: 2}
+
+  def self.current_app(application_id, pet_id)
+    where('application_id = ?', application_id).where('pet_id = ?', pet_id)
+  end
+
+  def pending?
+    self.status == "Pending"
+  end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -2,8 +2,8 @@ class Pet < ApplicationRecord
   validates :name, presence: true
   validates :age, presence: true, numericality: true
   belongs_to :shelter
-  has_many :application_pets
-  has_many :applications, through: :application_pets
+  has_many :application_pets, dependent: :destroy
+  has_many :applications, through: :application_pets, dependent: :destroy
 
   def shelter_name
     shelter.name

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -18,6 +18,13 @@
         <%= f.hidden_field :pid, value: application_pet.pet_id %>
         <%= f.submit "Approve" %>
       <% end %>
+
+      <%= form_with url: "/applications/#{@application.id}/pets", method: :patch, data: { turbo: false } do |f| %>
+        <%= f.hidden_field :status_update, value: 2 %>
+        <%= f.hidden_field :aid, value: @application.id %>
+        <%= f.hidden_field :pid, value: application_pet.pet_id %>
+        <%= f.submit "Reject" %>
+      <% end %>
     <% end %>
 
     <% if !application_pet.pending? %>

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -9,14 +9,21 @@
   <h2>Pets You Have Applied For</h2>
   <% @application.application_pets.each do |application_pet| %>
   <div id="pet-<%= application_pet.pet_id %>">
-    <%=application_pet.status %>
-    <%= link_to "#{application_pet.pet.name}", "/pets/#{application_pet.pet_id}" %>
-    <%= form_with url: "/applications/#{@application.id}/pets", method: :patch, data: { turbo: false } do |f| %>
-    <%= f.hidden_field :status_update, value: 1 %>
-    <%= f.hidden_field :aid, value: @application.id %>
-    <%= f.hidden_field :pid, value: application_pet.pet_id %>
-    <%= f.submit "Approve" %>
+    
+    <% if application_pet.pending? %>
+      <%= link_to "#{application_pet.pet.name}", "/pets/#{application_pet.pet_id}" %>
+      <%= form_with url: "/applications/#{@application.id}/pets", method: :patch, data: { turbo: false } do |f| %>
+        <%= f.hidden_field :status_update, value: 1 %>
+        <%= f.hidden_field :aid, value: @application.id %>
+        <%= f.hidden_field :pid, value: application_pet.pet_id %>
+        <%= f.submit "Approve" %>
+      <% end %>
     <% end %>
+
+    <% if !application_pet.pending? %>
+      <p><%= "#{application_pet.pet.name} : #{application_pet.status}" %></p>
+    <% end %>
+
   </div>
   <% end %>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,11 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+Application.destroy_all
+Shelter.destroy_all
+Pet.destroy_all
+
+
 @application_1 = Application.create!(name: "Billy", street: "Maritime Lane", city: "Springfield", state: "Virginia", zip: "22153", description: "Loving and likes to walk", status: "Pending")
 @application_2 = Application.create!(name: "Billy", street: "Maritime Lane", city: "Springfield", state: "Virginia", zip: "22153", description: "Loving and likes to walk", status: "In Progress")
 @application_3 = Application.create!(name: "Billy", street: "Maritime Lane", city: "Springfield", state: "Virginia", zip: "22153", description: "Loving and likes to walk", status: "Accepted")

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe "the shelters index" do
         end
 
         expect(current_path).to eq("/admin/applications/#{@application_1.id}")
-save_and_open_page
+
         within "#pet-#{@pet_1.id}" do
           expect(page).to have_content("#{@pet_1.name} : #{@application_1.application_pets.first.status}")       
-          expect(page).to_not have_button("Approve")
+          expect(page).to_not have_selector(:link_or_button, "Approve")
         end
 
       end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -87,6 +87,44 @@ RSpec.describe "the shelters index" do
     end
   end
 
+  context "User Story 14: Accepting/Rejecting is specific to an application" do
+    describe "As a visitor, when I visit an admin application page" do
+      it "For every pet on the application, I see a button to reject the application for that pet" do
+        visit "/applications/#{@application_1.id}"
+        fill_in "Search", with: "Ba"
+        click_on("Search")
+        
+        within "#pet-#{@pet_1.id}" do
+          click_button("Adopt this Pet")
+        end
+
+        within "#appliedPets" do
+          fill_in("add_qualifications", with: "I also have a dog named Lola who is a showgirl.")
+          click_button("Submit")
+        end
+
+        @application_1.pets << @pet_2
+        visit "/admin/applications/#{@application_1.id}"
+
+        within "#pet-#{@pet_2.id}" do
+          expect(page).to have_button("Reject")
+        end
+
+        within "#pet-#{@pet_1.id}" do
+          expect(page).to have_button("Reject")
+          click_button("Reject")
+        end
+
+        expect(current_path).to eq("/admin/applications/#{@application_1.id}")
+
+        within "#pet-#{@pet_1.id}" do
+          expect(page).to have_content("#{@pet_1.name} : #{@application_1.application_pets.first.status}")       
+          expect(page).to_not have_selector(:link_or_button, "Reject")
+        end
+      end
+    end
+  end
+
 
 
 end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "the shelters index" do
 
   context "User Story 12: Approving a Pet for Adoption" do
     describe "As a visitor, when I visit an admin application page" do
-      it "For every pet on the application, I see a button to approve the application for that pet" do
+      it "For every pet on the application, I see a button to approve the application for that pet, after approve redirects to admin show, button is gone, and status shown" do
         visit "/applications/#{@application_1.id}"
         fill_in "Search", with: "Ba"
         click_on("Search")
@@ -52,7 +52,7 @@ RSpec.describe "the shelters index" do
 
   context "User Story 13: Rejecting a Pet for Adoption" do
     describe "As a visitor, when I visit an admin application page" do
-      it "For every pet on the application, I see a button to reject the application for that pet" do
+      it "For every pet on the application, I see a button to reject the application for that pet, after reject redirects to admin show, button is gone, and status shown" do
         visit "/applications/#{@application_1.id}"
         fill_in "Search", with: "Ba"
         click_on("Search")
@@ -90,7 +90,7 @@ RSpec.describe "the shelters index" do
 
   context "User Story 14: Accepting/Rejecting is specific to an application" do
     describe "As a visitor, when I visit an admin application page" do
-      it "For every pet on the application, I see a button to reject the application for that pet" do
+      it "Accepting/Rejecting a pet application does not change the status of those same pets on another applicaton" do
         
         @application_1.pets << @pet_1
         @application_1.pets << @pet_2

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "the shelters index" do
     @pet_3 = Pet.create(adoptable: true, age: 4, breed: "chihuahua", name: "Elle", shelter_id: @shelter.id)
   end
 
-  describe "User Story 12: Approving a Pet for Adoption" do
+  context "User Story 12: Approving a Pet for Adoption" do
     describe "As a visitor, when I visit an admin application page" do
       it "For every pet on the application, I see a button to approve the application for that pet" do
         visit "/applications/#{@application_1.id}"
@@ -26,7 +26,13 @@ RSpec.describe "the shelters index" do
           fill_in("add_qualifications", with: "I also have a dog named Lola who is a showgirl.")
           click_button("Submit")
         end
+
+        @application_1.pets << @pet_2
         visit "/admin/applications/#{@application_1.id}"
+
+        within "#pet-#{@pet_2.id}" do
+          expect(page).to have_button("Approve")
+        end
 
         within "#pet-#{@pet_1.id}" do
           expect(page).to have_button("Approve")
@@ -39,11 +45,44 @@ RSpec.describe "the shelters index" do
           expect(page).to have_content("#{@pet_1.name} : #{@application_1.application_pets.first.status}")       
           expect(page).to_not have_selector(:link_or_button, "Approve")
         end
-
       end
+    end
+  end
 
-      it "When I click the button, I am taken back to the admin app show page where I don't see a button to approve, but do see an indicator saying the pet has been approved" do
+  context "User Story 13: Rejecting a Pet for Adoption" do
+    describe "As a visitor, when I visit an admin application page" do
+      it "For every pet on the application, I see a button to reject the application for that pet" do
+        visit "/applications/#{@application_1.id}"
+        fill_in "Search", with: "Ba"
+        click_on("Search")
+        
+        within "#pet-#{@pet_1.id}" do
+          click_button("Adopt this Pet")
+        end
 
+        within "#appliedPets" do
+          fill_in("add_qualifications", with: "I also have a dog named Lola who is a showgirl.")
+          click_button("Submit")
+        end
+
+        @application_1.pets << @pet_2
+        visit "/admin/applications/#{@application_1.id}"
+
+        within "#pet-#{@pet_2.id}" do
+          expect(page).to have_button("Reject")
+        end
+
+        within "#pet-#{@pet_1.id}" do
+          expect(page).to have_button("Reject")
+          click_button("Reject")
+        end
+
+        expect(current_path).to eq("/admin/applications/#{@application_1.id}")
+
+        within "#pet-#{@pet_1.id}" do
+          expect(page).to have_content("#{@pet_1.name} : #{@application_1.application_pets.first.status}")       
+          expect(page).to_not have_selector(:link_or_button, "Reject")
+        end
       end
     end
   end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "the shelters index" do
   before(:each) do
     @application_1 = Application.create!(name: "Billy", street: "Maritime Lane", city: "Springfield", state: "Virginia", zip: "22153", description: "Loving and likes to walk", status: "In Progress")
+    @application_2 = Application.create!(name: "Sam", street: "Oxford Cir", city: "Denver", state: "CO", zip: "22153", description: "Loving", status: "Pending")
       
     @shelter = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
 
@@ -90,53 +91,51 @@ RSpec.describe "the shelters index" do
   context "User Story 14: Accepting/Rejecting is specific to an application" do
     describe "As a visitor, when I visit an admin application page" do
       it "For every pet on the application, I see a button to reject the application for that pet" do
-        visit "/applications/#{@application_1.id}"
-        fill_in "Search", with: "Ba"
-        click_on("Search")
         
-        within "#pet-#{@pet_1.id}" do
-          click_button("Adopt this Pet")
-        end
-
-        within "#appliedPets" do
-          fill_in("add_qualifications", with: "I also have a dog named Lola who is a showgirl.")
-          click_button("Submit")
-        end
-
+        @application_1.pets << @pet_1
         @application_1.pets << @pet_2
+        @application_2.pets << @pet_1
+        @application_2.pets << @pet_2
+
         visit "/admin/applications/#{@application_1.id}"
 
-        within "#pet-#{@pet_2.id}" do
+        within "#pet-#{@pet_1.id}" do
+          expect(page).to have_button("Approve")
           expect(page).to have_button("Reject")
         end
 
+        within "#pet-#{@pet_2.id}" do
+          expect(page).to have_button("Approve")
+          expect(page).to have_button("Reject")
+        end
+
+        visit "/admin/applications/#{@application_2.id}"
+
         within "#pet-#{@pet_1.id}" do
+          expect(page).to have_button("Approve")
           expect(page).to have_button("Reject")
           click_button("Reject")
         end
 
-        expect(current_path).to eq("/admin/applications/#{@application_1.id}")
+        within "#pet-#{@pet_2.id}" do
+          expect(page).to have_button("Approve")
+          expect(page).to have_button("Reject")
+          click_button("Approve")
+        end
+
+        visit "/admin/applications/#{@application_1.id}"
 
         within "#pet-#{@pet_1.id}" do
-          expect(page).to have_content("#{@pet_1.name} : #{@application_1.application_pets.first.status}")       
-          expect(page).to_not have_selector(:link_or_button, "Reject")
+          expect(page).to have_button("Approve")
+          expect(page).to have_button("Reject")
+        end
+
+        within "#pet-#{@pet_2.id}" do
+          expect(page).to have_button("Approve")
+          expect(page).to have_button("Reject")
         end
       end
     end
   end
 
-
-
 end
-
-
-# 12. Approving a Pet for Adoption
-
-# As a visitor
-# When I visit an admin application show page ('/admin/applications/:id')
-# For every pet that the application is for, I see a button to approve the application for that specific pet
-# When I click that button
-# Then I'm taken back to the admin application show page
-# And next to the pet that I approved, I do not see a button to approve this pet
-# And instead I see an indicator next to the pet that they have been approved
-

--- a/spec/models/application_pet_spec.rb
+++ b/spec/models/application_pet_spec.rb
@@ -15,4 +15,46 @@ RSpec.describe ApplicationPet, type: :model do
       expect(ApplicationPet.statuses["Test"]).to eq(nil)
     end
   end
+
+  describe 'class methods' do
+    before(:each) do
+      @application_1 = Application.create!(name: "Billy", street: "Maritime Lane", city: "Springfield", state: "Virginia", zip: "22153", description: "Loving and likes to walk", status: "Pending")
+      @application_2 = Application.create!(name: "Billy", street: "Maritime Lane", city: "Springfield", state: "Virginia", zip: "22153", description: "Loving and likes to walk", status: "In Progress")
+      
+      @shelter = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
+
+      @pet_1 = Pet.create(adoptable: true, age: 7, breed: "sphynx", name: "Bare-y Manilow", shelter_id: @shelter.id)
+      @pet_2 = Pet.create(adoptable: true, age: 3, breed: "domestic pig", name: "Babe", shelter_id: @shelter.id)
+      @pet_3 = Pet.create(adoptable: true, age: 4, breed: "chihuahua", name: "Elle", shelter_id: @shelter.id)
+
+      @application_1.pets << @pet_1
+    end
+
+    describe 'current_app' do
+      it 'returns current application' do
+        expect(ApplicationPet.current_app(@application_1.id, @pet_1.id)).to eq(@application_1.application_pets)
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    before(:each) do
+      @application_1 = Application.create!(name: "Billy", street: "Maritime Lane", city: "Springfield", state: "Virginia", zip: "22153", description: "Loving and likes to walk", status: "Pending")
+      @application_2 = Application.create!(name: "Billy", street: "Maritime Lane", city: "Springfield", state: "Virginia", zip: "22153", description: "Loving and likes to walk", status: "In Progress")
+      
+      @shelter = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
+
+      @pet_1 = Pet.create(adoptable: true, age: 7, breed: "sphynx", name: "Bare-y Manilow", shelter_id: @shelter.id)
+      @pet_2 = Pet.create(adoptable: true, age: 3, breed: "domestic pig", name: "Babe", shelter_id: @shelter.id)
+      @pet_3 = Pet.create(adoptable: true, age: 4, breed: "chihuahua", name: "Elle", shelter_id: @shelter.id)
+
+      @application_1.pets << @pet_1
+    end
+
+   describe '.pending?' do
+     it 'returns true if Pending' do
+       expect(@application_1.application_pets.first.pending?).to eq(true)
+     end
+   end
+  end
 end


### PR DESCRIPTION
US12, 13, and 14, functionalities for approve and reject specific pets on the admin show page.
Added model methods to ApplicationPet to query current application, and pending status of that application.
The current_app method was leveraged to update the status of application_pets based on the enums previously set up. 
The pending? method was used to conditionally render the status of the pet application as well as accept/reject buttons.

Reject test was written, view was copied down and updated accordingly.

Test was written to ensure accepting/rejecting status is tied to a single application and does not have an effect on others. 